### PR TITLE
Add encoder support for drivetrain

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -14,5 +14,11 @@ public final class Constants {
     public static final int kLeftRearPort = 2;
     public static final int kRightFrontPort = 3;
     public static final int kRightRearPort = 4;
+
+    // Encoder calculation for rate and distance
+    public static final double k100msTo60sRatio = 600;
+    public static final double kEncoderResolution = 2048;
+    public static final double kMotorToWheelRatio = 4;
+    public static final double kWheelCircumference = 47.879;
   }
 }

--- a/src/main/java/frc/robot/subsystems/DriveTrain.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrain.java
@@ -62,4 +62,21 @@ public class DriveTrain extends SubsystemBase {
   public void calibrateIMU() {
     m_imu.calibrate();
   }
+
+  public double getDistance() {
+    double leftAvgPos = (m_leftFront.getSelectedSensorPosition() + m_leftRear.getSelectedSensorPosition()) / 2;
+    double rightAvgPos = (m_rightFront.getSelectedSensorPosition() + m_rightRear.getSelectedSensorPosition()) / 2;
+    double centralAvg = (leftAvgPos + rightAvgPos) / 2;
+    double centralMotorAvg = centralAvg / DriveTrainConstants.kEncoderResolution;
+    double centralWheelAvg = centralMotorAvg / DriveTrainConstants.kMotorToWheelRatio;
+
+    return centralWheelAvg * DriveTrainConstants.kWheelCircumference;
+  }
+
+  public void resetEncoders() {
+    m_leftFront.setSelectedSensorPosition(0);
+    m_leftRear.setSelectedSensorPosition(0);
+    m_rightFront.setSelectedSensorPosition(0);
+    m_rightRear.setSelectedSensorPosition(0);
+  }
 }

--- a/src/main/java/frc/robot/subsystems/DriveTrain.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrain.java
@@ -79,4 +79,21 @@ public class DriveTrain extends SubsystemBase {
     m_rightFront.setSelectedSensorPosition(0);
     m_rightRear.setSelectedSensorPosition(0);
   }
+
+  private double rawSpeedToRPM(double rawSpeed) {
+    return rawSpeed * DriveTrainConstants.k100msTo60sRatio / DriveTrainConstants.kEncoderResolution
+        / DriveTrainConstants.kMotorToWheelRatio;
+  }
+
+  public double getLeftWheelsRPM() {
+    return rawSpeedToRPM((m_leftFront.getSelectedSensorVelocity() + m_leftRear.getSelectedSensorVelocity()) / 2);
+  }
+
+  public double getRightWheelsRPM() {
+    return rawSpeedToRPM((m_rightFront.getSelectedSensorVelocity() + m_rightRear.getSelectedSensorVelocity()) / 2);
+  }
+
+  public double getAverageWheelsRPM() {
+    return (getLeftWheelsRPM() + getRightWheelsRPM()) / 2;
+  }
 }


### PR DESCRIPTION
## Added
* `getDistance()` to get the distance the robot passed since the last encoders reset.
* `resetEncoders()` to reset the encoders.
* `getLeftWheelsRPM()` to get the left wheels' RPM.
* `getRightWheelsRPM()` to get the right wheels' RPM.
* `getAverageWheelsRPM()` to get the average RPM of both sides' wheels.
* Some constants that are reused during calculation

Note - We need to change the constant kWheelCircumference to the actual value because thus far I couldn't get it, and we need to check if the motor to wheel rotation ratio is indeed 4:1 and edit kMotorToWheelRatio accordingly

Closes #16 